### PR TITLE
add queueing related code

### DIFF
--- a/examples/v1/dist-mnist/tf_job_mnist_queueing.yaml
+++ b/examples/v1/dist-mnist/tf_job_mnist_queueing.yaml
@@ -1,0 +1,23 @@
+apiVersion: "kubeflow.org/v1"
+kind: "TFJob"
+metadata:
+  name: "dist-mnist-for-e2e-test"
+  annotations: {"kube-queue": "pending"}
+spec:
+  tfReplicaSpecs:
+    PS:
+      replicas: 2
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: tensorflow
+              image: kubeflow/tf-dist-mnist-test:1.0
+    Worker:
+      replicas: 4
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: tensorflow
+              image: kubeflow/tf-dist-mnist-test:1.0


### PR DESCRIPTION
@denkensk 

Since tf-operator v1.0 is still not out, I add the queue logic based on v0.5.3

- [x] operator will read annotation of tfJob and prevent itself from further processing if the key of *kube-queue* is found

- [x] tfjob yaml file for e2e test 